### PR TITLE
Improved the DragHandle

### DIFF
--- a/Outlines.App/Resources/DarkThemeResources.xaml
+++ b/Outlines.App/Resources/DarkThemeResources.xaml
@@ -6,7 +6,7 @@
     <SolidColorBrush x:Key="ThemeAccentForegroundColorBrush" Color="Black" />
     <SolidColorBrush x:Key="ThemeDisabledForegroundColorBrush" Color="#707070" />
     <SolidColorBrush x:Key="ThemeAppBackgroundBrush" Color="#1D1D1D" />
-    <SolidColorBrush x:Key="ThemeDragHandleBackgroundBrush" Color="#555555" />
+    <SolidColorBrush x:Key="ThemeDragHandleBackgroundBrush" Color="#9B9B9B" />
     <SolidColorBrush x:Key="ThemePanelBackgroundBrush" Color="#2D2D2D" />
     <SolidColorBrush x:Key="ThemePanelBorderBrush" Color="#181818" />
     <SolidColorBrush x:Key="ThemeSeperatorBrush" Color="#40FFFFFF" />

--- a/Outlines.App/Resources/LightThemeResources.xaml
+++ b/Outlines.App/Resources/LightThemeResources.xaml
@@ -6,7 +6,7 @@
     <SolidColorBrush x:Key="ThemeAccentForegroundColorBrush" Color="White" />
     <SolidColorBrush x:Key="ThemeDisabledForegroundColorBrush" Color="#A0A0A0" />
     <SolidColorBrush x:Key="ThemeAppBackgroundBrush" Color="#FFFFFF" />
-    <SolidColorBrush x:Key="ThemeDragHandleBackgroundBrush" Color="#D8D8D8" />
+    <SolidColorBrush x:Key="ThemeDragHandleBackgroundBrush" Color="#797979" />
     <SolidColorBrush x:Key="ThemePanelBackgroundBrush" Color="#F8F8F8" />
     <SolidColorBrush x:Key="ThemePanelBorderBrush" Color="#D0D0D0" />
     <SolidColorBrush x:Key="ThemeSeperatorBrush" Color="#40000000" />

--- a/Outlines.App/Views/ColorPicker.xaml
+++ b/Outlines.App/Views/ColorPicker.xaml
@@ -16,9 +16,8 @@
         </Style>
     </UserControl.Resources>
 
-    <Grid>
-        <Border Style="{StaticResource SharedInspectorPanelStyle}" Effect="{StaticResource SharedShadowEffectLeft}" />
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="12,12,12,12">
+    <Grid x:Name="Root">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="12">
             <Grid Height="32" Width="32" Margin="0,0,16,0">
                 <Border Background="{Binding PickedColorBrush}" Style="{StaticResource ColorPreviewBorderStyle}" />
             </Grid>

--- a/Outlines.App/Views/ColorPicker.xaml.cs
+++ b/Outlines.App/Views/ColorPicker.xaml.cs
@@ -13,7 +13,7 @@ namespace Outlines.App.Views
 
         private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
         {
-            DataContext = ServiceContainer.Instance.GetService<ColorPickerViewModel>();
+            Root.DataContext = ServiceContainer.Instance.GetService<ColorPickerViewModel>();
         }
     }
 }

--- a/Outlines.App/Views/DragHandle.xaml
+++ b/Outlines.App/Views/DragHandle.xaml
@@ -1,16 +1,29 @@
 ﻿<UserControl x:Class="Outlines.App.Views.DragHandle"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Outlines.App.Views"
              mc:Ignorable="d">
     <UserControl.Resources>
         <Style x:Key="DragHandleStyle" TargetType="Border">
             <Setter Property="Background" Value="{DynamicResource ThemeDragHandleBackgroundBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource ThemePanelBorderBrush}" />
-            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderThickness" Value="0.5" />
             <Setter Property="CornerRadius" Value="2" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=Orientation, RelativeSource={RelativeSource AncestorType={x:Type local:DragHandle}}}" Value="Horizontal">
+                    <Setter Property="Width" Value="32" />
+                    <Setter Property="Height" Value="4.25" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Path=Orientation, RelativeSource={RelativeSource AncestorType={x:Type local:DragHandle}}}" Value="Vertical">
+                    <Setter Property="Width" Value="4.25" />
+                    <Setter Property="Height" Value="24" />
+                </DataTrigger>
+            </Style.Triggers>
         </Style>
     </UserControl.Resources>
-    <Border Style="{StaticResource DragHandleStyle}" />
+    <Grid Background="Transparent" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+        <Border Style="{StaticResource DragHandleStyle}" VerticalAlignment="Center" HorizontalAlignment="Center" />
+    </Grid>
 </UserControl>

--- a/Outlines.App/Views/DragHandle.xaml.cs
+++ b/Outlines.App/Views/DragHandle.xaml.cs
@@ -1,9 +1,19 @@
-﻿using System.Windows.Controls;
+﻿using System.Windows;
+using System.Windows.Controls;
 
 namespace Outlines.App.Views
 {
     public partial class DragHandle : UserControl
     {
+        public static readonly DependencyProperty OrientationProperty = 
+            DependencyProperty.Register("Orientation", typeof(Orientation), typeof(DragHandle), new PropertyMetadata(Orientation.Horizontal));
+
+        public Orientation Orientation
+        {
+            get => (Orientation)GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
         public DragHandle()
         {
             InitializeComponent();

--- a/Outlines.App/Views/InspectorPage.xaml
+++ b/Outlines.App/Views/InspectorPage.xaml
@@ -41,12 +41,12 @@
         <Grid Grid.Row="1">
             <local:InspectorPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
                                   Style="{StaticResource TreeViewPanelStyle}">
-                <local:UITreeView Margin="16" />
+                <local:UITreeView />
             </local:InspectorPanel>
             <StackPanel Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
                         Style="{StaticResource PropertiesPanelStyle}">
                 <local:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}">
-                    <local:PropertiesPanel Margin="16" />
+                    <local:PropertiesPanel />
                 </local:InspectorPanel>
                 <local:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}" Margin="0,12,0,0">
                     <local:ColorPicker />

--- a/Outlines.App/Views/InspectorPage.xaml
+++ b/Outlines.App/Views/InspectorPage.xaml
@@ -11,11 +11,12 @@
 
     <Page.Resources>
         <ResourceDictionary>
-            <Style x:Key="TreeViewPanelStyle" TargetType="StackPanel">
+            <Style x:Key="TreeViewPanelStyle" TargetType="local:InspectorPanel">
                 <Setter Property="Width" Value="240" />
                 <Setter Property="HorizontalAlignment" Value="Left" />
                 <Setter Property="VerticalAlignment" Value="Top" />
                 <Setter Property="Margin" Value="16,0,0,0" />
+                <Setter Property="Effect" Value="{StaticResource SharedShadowEffectRight}" />
             </Style>
             <Style x:Key="PropertiesPanelStyle" TargetType="StackPanel">
                 <Setter Property="Width" Value="240" />
@@ -34,16 +35,22 @@
         </Grid.RowDefinitions>
         <Border Background="Black" Opacity="0.3" Visibility="{Binding IsBackdropVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Collapsed}" Grid.RowSpan="3" />
         <local:OutlinesOverlay Visibility="{Binding IsOverlayVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" Grid.RowSpan="3" />
-        <local:ToolBar HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,12,0,0" />
+        <local:InspectorPanel Effect="{StaticResource SharedShadowEffectBottom}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,12,0,0">
+            <local:ToolBar />
+        </local:InspectorPanel>
         <Grid Grid.Row="1">
-            <StackPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
-                        Style="{StaticResource TreeViewPanelStyle}">
-                <local:UITreeView />
-            </StackPanel>
+            <local:InspectorPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
+                                  Style="{StaticResource TreeViewPanelStyle}">
+                <local:UITreeView Margin="16" />
+            </local:InspectorPanel>
             <StackPanel Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
                         Style="{StaticResource PropertiesPanelStyle}">
-                <local:ColorPicker Margin="0,0,0,12" />
-                <local:PropertiesPanel />
+                <local:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}">
+                    <local:PropertiesPanel Margin="16" />
+                </local:InspectorPanel>
+                <local:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}" Margin="0,12,0,0">
+                    <local:ColorPicker />
+                </local:InspectorPanel>
             </StackPanel>
         </Grid>
     </Grid>

--- a/Outlines.App/Views/InspectorPanel.xaml
+++ b/Outlines.App/Views/InspectorPanel.xaml
@@ -1,0 +1,11 @@
+﻿<Grid x:Class="Outlines.App.Views.InspectorPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d">
+
+        <Border Style="{StaticResource SharedInspectorPanelStyle}" />
+        <ContentPresenter />
+
+</Grid>

--- a/Outlines.App/Views/InspectorPanel.xaml.cs
+++ b/Outlines.App/Views/InspectorPanel.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Outlines.App.Views
+{
+    public partial class InspectorPanel : Grid
+    {
+        public InspectorPanel()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Outlines.App/Views/PropertiesPanel.xaml
+++ b/Outlines.App/Views/PropertiesPanel.xaml
@@ -33,8 +33,7 @@
     </UserControl.Resources>
 
     <Grid Name="Root" VerticalAlignment="Top">
-        <Border Style="{StaticResource SharedInspectorPanelStyle}" Effect="{StaticResource SharedShadowEffectRight}" />
-        <StackPanel Margin="16">
+        <StackPanel>
             <StackPanel x:Name="ElementPropertiesGroup" Margin="0,0,0,12">
                 <TextBlock Text="Element Properties" Style="{StaticResource PropertyGroupHeaderStyle}" />
                 <StackPanel Orientation="Horizontal">

--- a/Outlines.App/Views/PropertiesPanel.xaml
+++ b/Outlines.App/Views/PropertiesPanel.xaml
@@ -33,7 +33,7 @@
     </UserControl.Resources>
 
     <Grid Name="Root" VerticalAlignment="Top">
-        <StackPanel>
+        <StackPanel Margin="16">
             <StackPanel x:Name="ElementPropertiesGroup" Margin="0,0,0,12">
                 <TextBlock Text="Element Properties" Style="{StaticResource PropertyGroupHeaderStyle}" />
                 <StackPanel Orientation="Horizontal">

--- a/Outlines.App/Views/SnapshotInspectorPage.xaml
+++ b/Outlines.App/Views/SnapshotInspectorPage.xaml
@@ -18,44 +18,55 @@
                 <Setter Property="VerticalAlignment" Value="Top" />
                 <Setter Property="Margin" Value="0,7,0,0" />
             </Style>
-            <Style x:Key="TreeViewPanelStyle" TargetType="StackPanel">
+            <Style x:Key="TreeViewPanelStyle" TargetType="Grid">
                 <Setter Property="Width" Value="240" />
-                <Setter Property="HorizontalAlignment" Value="Left" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Margin" Value="16,0,0,0" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Margin" Value="0,75,12,0" />
             </Style>
-            <Style x:Key="PropertiesPanelStyle" TargetType="StackPanel">
+            <Style x:Key="PropertiesPanelStyle" TargetType="Grid">
                 <Setter Property="Width" Value="240" />
-                <Setter Property="HorizontalAlignment" Value="Right" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Margin" Value="0,0,16,0" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Margin" Value="12,75,0,0" />
             </Style>
         </ResourceDictionary>
     </Page.Resources>
 
     <Grid x:Name="Root">
         <TextBlock x:Name="Title" Text="Outlines Snapshots" Style="{StaticResource TitleStyle}" />
-        
-        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Transparent" Margin="0,35,0,0">
-            <Grid MouseWheel="OnMouseWheelScroll" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-                <Grid x:Name="InspectionArea" MouseDown="OnMouseDown" MouseMove="OnMouseMove" VerticalAlignment="Center" HorizontalAlignment="Center">
-                    <Grid.LayoutTransform>
-                        <ScaleTransform ScaleX="{Binding ScreenshotScaleFactor}" ScaleY="{Binding ScreenshotScaleFactor}" />
-                    </Grid.LayoutTransform>
-                    <Image x:Name="ScreenshotImage" Source="{Binding Snapshot.Screenshot, Converter={StaticResource ImageToImageSource}}" />
-                    <local:OutlinesOverlay />
-                </Grid>
+
+        <Grid Margin="24">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            
+            <Grid Grid.Column="0" Style="{StaticResource TreeViewPanelStyle}">
+                <Border BorderBrush="{DynamicResource ThemePanelBorderBrush}" BorderThickness="{StaticResource PanelBorderThickness}" CornerRadius="{StaticResource PanelCornerRadius}" />
+                <StackPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
+                    <local:UITreeView Margin="16" />
+                </StackPanel>
             </Grid>
-        </ScrollViewer>
-        <Grid>
-            <StackPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
-                        Style="{StaticResource TreeViewPanelStyle}">
-                <local:UITreeView />
-            </StackPanel>
-            <StackPanel Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}" 
-                        Style="{StaticResource PropertiesPanelStyle}">
-                <local:PropertiesPanel />
-            </StackPanel>
+            
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Transparent" Margin="0,35,0,0" Grid.Column="1">
+                <Grid MouseWheel="OnMouseWheelScroll" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+                    <Grid x:Name="InspectionArea" MouseDown="OnMouseDown" MouseMove="OnMouseMove" VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <Grid.LayoutTransform>
+                            <ScaleTransform ScaleX="{Binding ScreenshotScaleFactor}" ScaleY="{Binding ScreenshotScaleFactor}" />
+                        </Grid.LayoutTransform>
+                        <Image x:Name="ScreenshotImage" Source="{Binding Snapshot.Screenshot, Converter={StaticResource ImageToImageSource}}" />
+                        <local:OutlinesOverlay />
+                    </Grid>
+                </Grid>
+            </ScrollViewer>
+            
+            <Grid Grid.Column="2" Style="{StaticResource PropertiesPanelStyle}">
+                <Border BorderBrush="{DynamicResource ThemePanelBorderBrush}" BorderThickness="{StaticResource PanelBorderThickness}" CornerRadius="{StaticResource PanelCornerRadius}" />
+                <StackPanel Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
+                    <local:PropertiesPanel Margin="16" />
+                </StackPanel>
+            </Grid>
+            
         </Grid>
     </Grid>
 </Page>

--- a/Outlines.App/Views/SnapshotInspectorPage.xaml
+++ b/Outlines.App/Views/SnapshotInspectorPage.xaml
@@ -40,12 +40,10 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            
-            <Grid Grid.Column="0" Style="{StaticResource TreeViewPanelStyle}">
+
+            <Grid Grid.Column="0" Style="{StaticResource TreeViewPanelStyle}" Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
                 <Border BorderBrush="{DynamicResource ThemePanelBorderBrush}" BorderThickness="{StaticResource PanelBorderThickness}" CornerRadius="{StaticResource PanelCornerRadius}" />
-                <StackPanel Visibility="{Binding IsTreeViewVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
-                    <local:UITreeView Margin="16" />
-                </StackPanel>
+                <local:UITreeView />
             </Grid>
             
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Background="Transparent" Margin="0,35,0,0" Grid.Column="1">
@@ -59,12 +57,10 @@
                     </Grid>
                 </Grid>
             </ScrollViewer>
-            
-            <Grid Grid.Column="2" Style="{StaticResource PropertiesPanelStyle}">
+
+            <Grid Grid.Column="2" Style="{StaticResource PropertiesPanelStyle}" Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
                 <Border BorderBrush="{DynamicResource ThemePanelBorderBrush}" BorderThickness="{StaticResource PanelBorderThickness}" CornerRadius="{StaticResource PanelCornerRadius}" />
-                <StackPanel Visibility="{Binding IsPropertiesPanelVisible, Converter={StaticResource BoolToVisibility}, FallbackValue=Visible}">
-                    <local:PropertiesPanel Margin="16" />
-                </StackPanel>
+                <local:PropertiesPanel />
             </Grid>
             
         </Grid>

--- a/Outlines.App/Views/ToolBar.xaml
+++ b/Outlines.App/Views/ToolBar.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Outlines.App.Views.ToolBar"
+<UserControl x:Class="Outlines.App.Views.ToolBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -6,24 +6,9 @@
              xmlns:local="clr-namespace:Outlines.App.Views"
              mc:Ignorable="d" 
              Loaded="OnLoaded">
-    
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <Style x:Key="ToolBarStyle" TargetType="Border">
-                <Setter Property="Background" Value="{DynamicResource ThemePanelBackgroundBrush}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource ThemePanelBorderBrush}" />
-                <Setter Property="BorderThickness" Value="{StaticResource PanelBorderThickness}" />
-                <Setter Property="CornerRadius" Value="{StaticResource PanelCornerRadius}" />
-                <Setter Property="HorizontalAlignment" Value="Stretch" />
-                <Setter Property="Effect" Value="{StaticResource SharedShadowEffectBottom}" />
-            </Style>
-        </ResourceDictionary>
-    </UserControl.Resources>
 
     <Grid Name="Root">
-        <Border Style="{StaticResource ToolBarStyle}" />
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="8">
-            <Border x:Name="Handle" Height="35" Width="4" CornerRadius="1" Margin="0,0,5,0" Background="#38000000" BorderBrush="#40000000" BorderThickness="1" VerticalAlignment="Center" Visibility="Collapsed" />
             <local:ToolBarToggleButton Content="&#xE721;" IsChecked="{Binding IsOverlayVisible, Mode=TwoWay}" ToolTip="Toggle Overlay" />
             <local:ToolBarToggleButton Content="&#xF003;" IsChecked="{Binding IsTreeViewVisible, Mode=TwoWay}" ToolTip="Toggle Tree View" />
             <local:ToolBarToggleButton Content="&#xE71D;" IsChecked="{Binding IsPropertiesPanelVisible, Mode=TwoWay}" ToolTip="Toggle Properties Panel" />

--- a/Outlines.App/Views/ToolBar.xaml.cs
+++ b/Outlines.App/Views/ToolBar.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
 using Outlines.App.Services;
 using Outlines.App.ViewModels;
 

--- a/Outlines.App/Views/UITreeView.xaml
+++ b/Outlines.App/Views/UITreeView.xaml
@@ -26,12 +26,13 @@
             </Style>
             <Style x:Key="TreeViewItemStyle" TargetType="TreeViewItem">
                 <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundColorBrush}" />
+                <Setter Property="Margin" Value="0,0,0,4" />
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid x:Name="Root">
-        <StackPanel Margin="16">
+        <StackPanel Margin="16,16,12,12">
             <TextBlock Text="Tree View" Style="{StaticResource HeaderStyle}" />
             <TreeView ItemsSource="{Binding Elements}" Style="{StaticResource TreeViewStyle}" ItemContainerStyle="{StaticResource TreeViewItemStyle}" SelectedItemChanged="OnSelectedItemChanged">
                 <TreeView.Resources>

--- a/Outlines.App/Views/UITreeView.xaml
+++ b/Outlines.App/Views/UITreeView.xaml
@@ -18,7 +18,7 @@
                 <Setter Property="Margin" Value="0,0,0,8" />
             </Style>
             <Style x:Key="TreeViewStyle" TargetType="TreeView">
-                <Setter Property="Background" Value="{DynamicResource ThemePanelBackgroundBrush}" />
+                <Setter Property="Background" Value="Transparent" />
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Margin" Value="-8,0,0,0" />
                 <Setter Property="MaxHeight" Value="450" />
@@ -31,9 +31,7 @@
     </UserControl.Resources>
 
     <Grid x:Name="Root">
-        <Border Style="{StaticResource SharedInspectorPanelStyle}" Effect="{StaticResource SharedShadowEffectLeft}" />
-
-        <StackPanel Margin="16,16,8,8">
+        <StackPanel>
             <TextBlock Text="Tree View" Style="{StaticResource HeaderStyle}" />
             <TreeView ItemsSource="{Binding Elements}" Style="{StaticResource TreeViewStyle}" ItemContainerStyle="{StaticResource TreeViewItemStyle}" SelectedItemChanged="OnSelectedItemChanged">
                 <TreeView.Resources>

--- a/Outlines.App/Views/UITreeView.xaml
+++ b/Outlines.App/Views/UITreeView.xaml
@@ -31,7 +31,7 @@
     </UserControl.Resources>
 
     <Grid x:Name="Root">
-        <StackPanel>
+        <StackPanel Margin="16">
             <TextBlock Text="Tree View" Style="{StaticResource HeaderStyle}" />
             <TreeView ItemsSource="{Binding Elements}" Style="{StaticResource TreeViewStyle}" ItemContainerStyle="{StaticResource TreeViewItemStyle}" SelectedItemChanged="OnSelectedItemChanged">
                 <TreeView.Resources>

--- a/Outlines.App/Windows/PropertiesWindow.xaml
+++ b/Outlines.App/Windows/PropertiesWindow.xaml
@@ -21,21 +21,24 @@
                 <Setter Property="Margin" Value="16" />
             </Style>
             <Style x:Key="HandleStyle" TargetType="views:DragHandle">
-                <Setter Property="Width" Value="48" />
-                <Setter Property="Height" Value="6" />
-                <Setter Property="Margin" Value="0,14,0,0" />
-                <Setter Property="HorizontalAlignment" Value="Center" />
-                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Orientation" Value="Horizontal" />
+                <Setter Property="Height" Value="28" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
     
     <Grid x:Name="Root" HorizontalAlignment="Center" VerticalAlignment="Center">
         <StackPanel Style="{StaticResource PropertiesPanelStyle}">
-            <views:ColorPicker Margin="0,0,0,12" />
-            <views:PropertiesPanel />
+            <views:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}">
+                <StackPanel Orientation="Vertical">
+                    <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Properties Window" />
+                    <views:PropertiesPanel Margin="16,0,16,16" />                     
+                </StackPanel>
+            </views:InspectorPanel>
+            <views:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}" Margin="0,12,0,0">
+                <views:ColorPicker />
+            </views:InspectorPanel>
         </StackPanel>
-        <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Properties Window" />
     </Grid>
     
 </Window>

--- a/Outlines.App/Windows/PropertiesWindow.xaml
+++ b/Outlines.App/Windows/PropertiesWindow.xaml
@@ -23,6 +23,7 @@
             <Style x:Key="HandleStyle" TargetType="views:DragHandle">
                 <Setter Property="Orientation" Value="Horizontal" />
                 <Setter Property="Height" Value="28" />
+                <Setter Property="Margin" Value="0,0,0,-16" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
@@ -32,7 +33,7 @@
             <views:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}">
                 <StackPanel Orientation="Vertical">
                     <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Properties Window" />
-                    <views:PropertiesPanel Margin="16,0,16,16" />                     
+                    <views:PropertiesPanel />                     
                 </StackPanel>
             </views:InspectorPanel>
             <views:InspectorPanel Effect="{StaticResource SharedShadowEffectLeft}" Margin="0,12,0,0">

--- a/Outlines.App/Windows/ToolBarWindow.xaml
+++ b/Outlines.App/Windows/ToolBarWindow.xaml
@@ -17,18 +17,20 @@
     <Window.Resources>
         <ResourceDictionary>
             <Style x:Key="HandleStyle" TargetType="views:DragHandle">
-                <Setter Property="Width" Value="6" />
-                <Setter Property="Height" Value="32" />
-                <Setter Property="HorizontalAlignment" Value="Left" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Margin" Value="13,0,0,0" />
+                <Setter Property="Orientation" Value="Vertical" />
+                <Setter Property="Width" Value="20" />
+                <Setter Property="Margin" Value="0,0,-12,0" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
-    
+
     <Grid x:Name="Root" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <views:ToolBar Margin="15" />
-        <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag ToolBar" />
+        <views:InspectorPanel Effect="{StaticResource SharedShadowEffectBottom}" Margin="16">
+            <StackPanel Orientation="Horizontal">
+                <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag ToolBar" />
+                <views:ToolBar />
+            </StackPanel>
+        </views:InspectorPanel>
     </Grid>
     
 </Window>

--- a/Outlines.App/Windows/TreeViewWindow.xaml
+++ b/Outlines.App/Windows/TreeViewWindow.xaml
@@ -16,25 +16,26 @@
     
     <Window.Resources>
         <ResourceDictionary>
-            <Style x:Key="TreeViewPanelStyle" TargetType="views:UITreeView">
+            <Style x:Key="TreeViewPanelStyle" TargetType="views:InspectorPanel">
                 <Setter Property="MaxWidth" Value="320" />
                 <Setter Property="MinWidth" Value="240" />
                 <Setter Property="MaxHeight" Value="1000" />
                 <Setter Property="Margin" Value="16" />
             </Style>
             <Style x:Key="HandleStyle" TargetType="views:DragHandle">
-                <Setter Property="Width" Value="48" />
-                <Setter Property="Height" Value="6" />
-                <Setter Property="Margin" Value="0,14,0,0" />
-                <Setter Property="HorizontalAlignment" Value="Center" />
-                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="Orientation" Value="Horizontal" />
+                <Setter Property="Height" Value="28" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
-    
+
     <Grid x:Name="Root" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <views:UITreeView Style="{StaticResource TreeViewPanelStyle}" />
-        <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Tree View Window" />
+        <views:InspectorPanel Style="{StaticResource TreeViewPanelStyle}" Effect="{StaticResource SharedShadowEffectRight}">
+            <StackPanel Orientation="Vertical">
+                <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Tree View Window" />
+                <views:UITreeView Margin="16,0,16,16" />
+            </StackPanel>
+        </views:InspectorPanel>
     </Grid>
     
 </Window>

--- a/Outlines.App/Windows/TreeViewWindow.xaml
+++ b/Outlines.App/Windows/TreeViewWindow.xaml
@@ -25,6 +25,7 @@
             <Style x:Key="HandleStyle" TargetType="views:DragHandle">
                 <Setter Property="Orientation" Value="Horizontal" />
                 <Setter Property="Height" Value="28" />
+                <Setter Property="Margin" Value="0,0,0,-16" />
             </Style>
         </ResourceDictionary>
     </Window.Resources>
@@ -33,7 +34,7 @@
         <views:InspectorPanel Style="{StaticResource TreeViewPanelStyle}" Effect="{StaticResource SharedShadowEffectRight}">
             <StackPanel Orientation="Vertical">
                 <views:DragHandle MouseDown="OnHandleMouseDown" Style="{StaticResource HandleStyle}" ToolTip="Drag Tree View Window" />
-                <views:UITreeView Margin="16,0,16,16" />
+                <views:UITreeView />
             </StackPanel>
         </views:InspectorPanel>
     </Grid>


### PR DESCRIPTION
- Made the UI of the DragHandle more consistent with drag handles in Windows 11 (eg. voice typing flyout, emoji keyboard).
- Made area around the handle clickable to drag, making dragging easier.
- Updated the structure of the inspector components and windows to insert the drag handle instead of superposing it.
- Re-ordered the properties panel and the color picker.
- Made the inspector components flat and transparent in the Snapshot inspector. 

**Screenshots**
Before:
![image](https://user-images.githubusercontent.com/12770956/147908646-168f2710-f977-475c-91cb-a0512c799933.png)

After:
![image](https://user-images.githubusercontent.com/12770956/147908516-705d2989-1484-4fa3-9cfd-811967355e95.png)

Reference:
![image](https://user-images.githubusercontent.com/12770956/147908683-80ab8ceb-b071-4bd4-a42f-e9e990db5fd1.png)
![image](https://user-images.githubusercontent.com/12770956/147908712-838878a4-63b6-468f-938c-f3d36b25ac70.png)

