### PR TITLE
Added Snapshot notifications

### DIFF
--- a/Outlines.App/App.xaml.cs
+++ b/Outlines.App/App.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using Outlines.Core;
 using Outlines.App.Services;
+using Microsoft.Toolkit.Uwp.Notifications;
 
 namespace Outlines.App
 {
@@ -12,13 +13,21 @@ namespace Outlines.App
 
         private void OnStartup(object sender, StartupEventArgs e)
         {
-            string fileToOpen = e.Args.Length > 0 ? e.Args[0] : null;
-
             ThemeManager = new ThemeManager();
 
-            if (!string.IsNullOrWhiteSpace(fileToOpen) && File.Exists(fileToOpen))
+            ToastNotificationManagerCompat.OnActivated += OnToastActivated;
+            if (ToastNotificationManagerCompat.WasCurrentProcessToastActivated())
             {
-                var snapshot = Snapshot.LoadFromFile(fileToOpen);
+                // We were activated by a toast notification, we'll wait for OnToastActivated to be
+                // called to show the Snapshot inspector, so we don't want to show the live inspector.
+                return;
+            }
+
+            string snapshotFileToOpen = e.Args.Length > 0 ? e.Args[0] : null;
+
+            if (!string.IsNullOrWhiteSpace(snapshotFileToOpen) && File.Exists(snapshotFileToOpen))
+            {
+                var snapshot = Snapshot.LoadFromFile(snapshotFileToOpen);
                 var window = new SnapshotInspectorWindow(snapshot, ThemeManager);
                 window.Show();
             }
@@ -26,6 +35,22 @@ namespace Outlines.App
             {
                 LiveInspector = new MultiWindowLiveInspector();
                 LiveInspector.Show();
+            }
+        }
+
+        private void OnToastActivated(ToastNotificationActivatedEventArgsCompat toastArgs)
+        {
+            string snapshotFileToOpen = toastArgs.Argument;
+
+            if (!string.IsNullOrWhiteSpace(snapshotFileToOpen) && File.Exists(snapshotFileToOpen))
+            {
+                var snapshot = Snapshot.LoadFromFile(snapshotFileToOpen);
+
+                Dispatcher.Invoke(() =>
+                {
+                    var window = new SnapshotInspectorWindow(snapshot, ThemeManager);
+                    window.Show();
+                });
             }
         }
 

--- a/Outlines.App/ViewModels/ToolBarViewModel.cs
+++ b/Outlines.App/ViewModels/ToolBarViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -100,7 +100,8 @@ namespace Outlines.App.ViewModels
             if (OutlinesService.SelectedElementProperties != null)
             {
                 Snapshot snapshot = SnapshotService.TakeSnapshot(OutlinesService.SelectedElementProperties);
-                SnapshotService.SaveSnapshot(snapshot);
+                string snapshotFilePath = SnapshotService.SaveSnapshot(snapshot);
+                SnapshotService.ShowSnapshotNotitication(snapshot, snapshotFilePath);
             }
         }
 
@@ -110,7 +111,8 @@ namespace Outlines.App.ViewModels
             var windowBounds = new Rectangle((int)window.Left, (int)window.Top, (int)window.Width, (int)window.Height);
             var screenWindowBounds = CoordinateConverter.RectToScreen(windowBounds);
             Snapshot snapshot = SnapshotService.TakeSnapshot(screenWindowBounds);
-            SnapshotService.SaveSnapshot(snapshot);
+            string snapshotFilePath = SnapshotService.SaveSnapshot(snapshot);
+            SnapshotService.ShowSnapshotNotitication(snapshot, snapshotFilePath);
         }
 
         private void TakeScreenshot()
@@ -132,6 +134,5 @@ namespace Outlines.App.ViewModels
             string filePath = Path.Combine(FolderConfig.GetScreenshotsFolderPath(), fileName);
             screenshot.Save(filePath, ImageFormat.Png);
         }
-
     }
 }

--- a/Outlines.Inspection/FolderConfig.cs
+++ b/Outlines.Inspection/FolderConfig.cs
@@ -5,7 +5,8 @@ namespace Outlines.Inspection
 {
     public class FolderConfig : IFolderConfig
     {
-        private readonly string ImagesRootFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "Outlines");
+        private readonly string ImagesRootFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), 
+                                                                @"Pictures\Outlines");
         private string ScreenshotsFolderPath { get; set; }
         private string SnapshotsFolderPath { get; set; }
 

--- a/Outlines.Inspection/ISnapshotService.cs
+++ b/Outlines.Inspection/ISnapshotService.cs
@@ -7,6 +7,7 @@ namespace Outlines.Inspection
     {
         Snapshot TakeSnapshot(Rectangle bounds);
         Snapshot TakeSnapshot(ElementProperties elementProperties);
-        void SaveSnapshot(Snapshot snapshot);
+        string SaveSnapshot(Snapshot snapshot);
+        void ShowSnapshotNotitication(Snapshot snapshot, string snapshotFilePath);
     }
 }

--- a/Outlines.Inspection/Outlines.Inspection.csproj
+++ b/Outlines.Inspection/Outlines.Inspection.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageReference Include="Microsoft.Windows.Apps.Test" Version="1.0.181205002" />
   </ItemGroup>
 

--- a/Outlines.Package/Package.appxmanifest
+++ b/Outlines.Package/Package.appxmanifest
@@ -3,8 +3,10 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  IgnorableNamespaces="uap rescap com desktop">
 
   <Identity
     Name="outlines"
@@ -39,6 +41,20 @@
         <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png"  Square71x71Logo="Images\SmallTile.png" Square310x310Logo="Images\LargeTile.png"/>
         <uap:SplashScreen Image="Images\SplashScreen.png" />
       </uap:VisualElements>
+
+      <Extensions>
+        <desktop:Extension Category="windows.toastNotificationActivation">
+          <desktop:ToastNotificationActivation ToastActivatorCLSID="DF48DC9A-3C3F-421B-B920-8A2EFA37FE0E" />
+        </desktop:Extension>
+
+        <com:Extension Category="windows.comServer">
+          <com:ComServer>
+            <com:ExeServer Executable="Outlines.App\Outlines.exe" Arguments="-ToastActivated" DisplayName="Toast activator">
+              <com:Class Id="DF48DC9A-3C3F-421B-B920-8A2EFA37FE0E" DisplayName="Toast activator"/>
+            </com:ExeServer>
+          </com:ComServer>
+        </com:Extension>
+      </Extensions>
     </Application>
   </Applications>
 


### PR DESCRIPTION
Added toast notifications when we take a Snapshot (issue #58), activating the toast notification opens the Snapshot in the Snapshot inspector.

Screenshots:
![image](https://user-images.githubusercontent.com/12770956/178898717-5ecad45c-4e9e-430a-bdff-06ae3cc51fb2.png)
