### PR TITLE
Made target and selected elements properties dynamically update

### DIFF
--- a/Outlines.App/Services/MultiWindowLiveInspector.cs
+++ b/Outlines.App/Services/MultiWindowLiveInspector.cs
@@ -18,6 +18,7 @@ namespace Outlines.App.Services
         private IInspectorStateManager InspectorStateManager { get; set; }
         private IOutlinesService OutlinesService { get; set; }
         private IScreenHelper ScreenHelper { get; set; }
+        private AutomationPropertiesWatcher AutomationPropertiesWatcher { get; set; }
         private WindowZOrderHelper WindowZOrderHelper { get; set; } = new WindowZOrderHelper();
         private UiaWindowHelper UiaWindowHelper { get; set; } = new UiaWindowHelper();
         private IgnorableWindowsSource IgnorableWindowsSource { get; set; } = new IgnorableWindowsSource();
@@ -132,6 +133,8 @@ namespace Outlines.App.Services
             CoordinateConverter = new CachedCoordinateConverter(ScreenHelper.GetDisplayScaleFactor(), new System.Drawing.Point(0, 0));
             OutlinesService = new OutlinesService(distanceOutlinesProvider, elementProvider);
             OutlinesService.TargetElementChanged += OnTargetElementChanged;
+
+            AutomationPropertiesWatcher = new AutomationPropertiesWatcher(OutlinesService, elementPropertiesProvider);
 
             InspectorStateManager = new InspectorStateManager();
             InspectorStateManager.IsOverlayVisibleChanged += OnIsOverlayVisibleChanged;

--- a/Outlines.Inspection/AutomationPropertiesWatcher.cs
+++ b/Outlines.Inspection/AutomationPropertiesWatcher.cs
@@ -1,0 +1,102 @@
+﻿using UIAutomationClient;
+using Outlines.Core;
+
+namespace Outlines.Inspection
+{
+    public class AutomationPropertiesWatcher
+    {
+        private delegate void AutomationPropertyChangedHandler(IUIAutomationElement sender);
+        private delegate void AutomationEventHandler(IUIAutomationElement sender, int eventId);
+
+        private class AutomationPropertyChangedHandlerImpl : IUIAutomationPropertyChangedEventHandler
+        {
+            private AutomationPropertyChangedHandler HandlerFunc { get; set; }
+
+            public AutomationPropertyChangedHandlerImpl(AutomationPropertyChangedHandler handlerFunc)
+            {
+                HandlerFunc = handlerFunc;
+            }
+
+            public void HandlePropertyChangedEvent(IUIAutomationElement sender, int propertyId, object newValue)
+            {
+                HandlerFunc(sender);
+            }
+        }
+
+        private class AutomationEventHandlerImpl : IUIAutomationEventHandler
+        {
+            private AutomationEventHandler HandlerFunc { get; set; }
+
+            public AutomationEventHandlerImpl(AutomationEventHandler handlerFunc)
+            {
+                HandlerFunc = handlerFunc;
+            }
+
+            public void HandleAutomationEvent(IUIAutomationElement sender, int eventId)
+            {
+                HandlerFunc(sender, eventId);
+            }
+        }
+
+        private static readonly int[] PropertiesToWatch = new int[]
+        {
+            UIA_PropertyIds.UIA_AutomationIdPropertyId,
+            UIA_PropertyIds.UIA_BoundingRectanglePropertyId,
+            UIA_PropertyIds.UIA_ClassNamePropertyId,
+            UIA_PropertyIds.UIA_ControlTypePropertyId,
+            UIA_PropertyIds.UIA_NamePropertyId,
+            UIA_PropertyIds.UIA_IsOffscreenPropertyId,
+            UIA_PropertyIds.UIA_ClickablePointPropertyId,
+            UIA_PropertyIds.UIA_CenterPointPropertyId,
+        };
+
+        private IUIAutomation UIAutomation { get; set; } = new CUIAutomation();
+        private IOutlinesService OutlinesService { get; set; }
+        private IElementPropertiesProvider ElementPropertiesProvider { get; set; }
+        private IUIAutomationElement WatchedElement { get; set; }
+        private IUIAutomationPropertyChangedEventHandler WatchedElementPropertyChangedEventHandler { get; set; }
+        private IUIAutomationEventHandler WatchedElementEventHandler { get; set; }
+
+        public AutomationPropertiesWatcher(IOutlinesService outlinesService, IElementPropertiesProvider elementPropertiesProvider)
+        {
+            ElementPropertiesProvider = elementPropertiesProvider;
+            OutlinesService = outlinesService;
+
+            WatchedElementPropertyChangedEventHandler = new AutomationPropertyChangedHandlerImpl(OnWatchedElementPropertyChanged);
+            WatchedElementEventHandler = new AutomationEventHandlerImpl(OnWatchedElementEvent);
+            OutlinesService.SelectedElementChanged += OnSelectedElementChanged;
+        }
+
+        private void OnSelectedElementChanged()
+        {
+            if (WatchedElement != null)
+            {
+                UIAutomation.RemovePropertyChangedEventHandler(WatchedElement, WatchedElementPropertyChangedEventHandler);
+                UIAutomation.RemoveAutomationEventHandler(UIA_EventIds.UIA_LayoutInvalidatedEventId, WatchedElement, WatchedElementEventHandler);
+            }
+
+            var automationElementProperties = OutlinesService.SelectedElementProperties as AutomationElementProperties;
+            if (automationElementProperties != null)
+            {
+                WatchedElement = automationElementProperties.Element;
+                UIAutomation.AddPropertyChangedEventHandler(WatchedElement, TreeScope.TreeScope_Element, null, 
+                                                            WatchedElementPropertyChangedEventHandler, PropertiesToWatch);
+
+                UIAutomation.AddAutomationEventHandler(UIA_EventIds.UIA_LayoutInvalidatedEventId, WatchedElement, 
+                                                       TreeScope.TreeScope_Parent, null, WatchedElementEventHandler);
+            }
+        }
+
+        private void OnWatchedElementPropertyChanged(IUIAutomationElement sender)
+        {
+            ElementProperties elementProperties = ElementPropertiesProvider.GetElementProperties(sender);
+            OutlinesService.SelectElementWithProperties(elementProperties);
+        }
+
+        private void OnWatchedElementEvent(IUIAutomationElement sender, int eventId)
+        {
+            ElementProperties elementProperties = ElementPropertiesProvider.GetElementProperties(WatchedElement);
+            OutlinesService.SelectElementWithProperties(elementProperties);
+        }
+    }
+}


### PR DESCRIPTION
Previously, if a target or select element moved its bounding rectangle did not update so the overlay ended up out of sync with the actual element. This change adds AutomationPropertiesWatcher which updates the element properties of the target and selected elements every 300ms so that they are always up to date. It also invalidates any UI elements that are not available anymore. See issues #62 and #63.