### PR TITLE
Updated ScrollBar UI to resemble Windows 11 design language

### DIFF
--- a/Outlines.App/App.xaml
+++ b/Outlines.App/App.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/SharedResources.xaml" />
+                <ResourceDictionary Source="Resources/ScrollBarResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Outlines.App/Resources/ScrollBarResources.xaml
+++ b/Outlines.App/Resources/ScrollBarResources.xaml
@@ -5,182 +5,181 @@
     <SolidColorBrush x:Key="LineButtonRestBrush" Color="#9F9F9F" />
     <SolidColorBrush x:Key="LineButtonHoveredBrush" Color="#CFCFCF" />
     <SolidColorBrush x:Key="ScrollBarBackgroundBrush" Color="#5F5F5F" />
-  
+
     <!-- Based on https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
-    
-      <Style TargetType="{x:Type Thumb}">
-      <Setter Property="SnapsToDevicePixels" Value="True" />
-      <Setter Property="OverridesDefaultStyle" Value="True"/>
-      <Setter Property="IsTabStop" Value="False"/>
-      <Setter Property="Focusable" Value="False" />
-      <Setter Property="Background" Value="{StaticResource ThumbBackgroundBrush}" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="{x:Type Thumb}">
-            <Border x:Name="ThumbBackgroundBorder"
-                    Background="{TemplateBinding Background}"
-                    Height="{TemplateBinding Height}"
-                    Width="{TemplateBinding Width}" 
-                    SnapsToDevicePixels="True"
-                    CornerRadius="3" />
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+    <Style TargetType="{x:Type Thumb}">
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Background" Value="{StaticResource ThumbBackgroundBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Border x:Name="ThumbBackgroundBorder"
+                            Background="{TemplateBinding Background}"
+                            Height="{TemplateBinding Height}"
+                            Width="{TemplateBinding Width}"
+                            SnapsToDevicePixels="True"
+                            CornerRadius="3" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
-  
+
     <Style x:Key="ScrollBarLineButton" TargetType="{x:Type RepeatButton}">
-      <Setter Property="SnapsToDevicePixels" Value="True" />
-      <Setter Property="OverridesDefaultStyle" Value="True" />
-      <Setter Property="Focusable" Value="False" />
-      <Setter Property="FontSize" Value="8" />
-      <Setter Property="FontFamily" Value="Segoe Fluent Icons" />
-      <Setter Property="Foreground" Value="{StaticResource LineButtonRestBrush}" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="{x:Type RepeatButton}">
-            <ContentPresenter Content="&#xF5B0;" />
-            <ControlTemplate.Triggers>
-              <Trigger Property="IsMouseOver" Value="True">
-                  <Setter Property="Foreground" Value="{StaticResource LineButtonHoveredBrush}" />
-              </Trigger>
-          </ControlTemplate.Triggers>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="FontSize" Value="8" />
+        <Setter Property="FontFamily" Value="Segoe Fluent Icons" />
+        <Setter Property="Foreground" Value="{StaticResource LineButtonRestBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <ContentPresenter Content="&#xF5B0;" />
+                      <ControlTemplate.Triggers>
+                          <Trigger Property="IsMouseOver" Value="True">
+                              <Setter Property="Foreground" Value="{StaticResource LineButtonHoveredBrush}" />
+                          </Trigger>
+                      </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
-  
+
     <Style x:Key="ScrollBarPageButton" TargetType="{x:Type RepeatButton}">
-      <Setter Property="SnapsToDevicePixels" Value="True" />
-      <Setter Property="OverridesDefaultStyle" Value="True" />
-      <Setter Property="IsTabStop" Value="False" />
-      <Setter Property="Focusable" Value="False" />
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="{x:Type RepeatButton}">
-            <Border Background="Transparent" />
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                    <Border Background="Transparent" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <ControlTemplate x:Key="HorizontalScrollBar" TargetType="{x:Type ScrollBar}">
-      <Grid SnapsToDevicePixels="True">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition MaxWidth="12" />
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition MaxWidth="12" />
-        </Grid.ColumnDefinitions>
-        <Border x:Name="ScrollBarBackground" 
-                Grid.ColumnSpan="3" 
-                Background="{StaticResource ScrollBarBackgroundBrush}" 
-                Opacity="0.01" 
-                CornerRadius="6" />
-        <RepeatButton x:Name="LineLeftButton"
-                      Grid.Column="0"
-                      Width="8"
-                      Style="{StaticResource ScrollBarLineButton}"
-                      Command="ScrollBar.LineLeftCommand"
-                      VerticalAlignment="Center"
-                      Visibility="Collapsed">
-          <RepeatButton.RenderTransform>
-            <RotateTransform CenterX="4" CenterY="4" Angle="180" />
-          </RepeatButton.RenderTransform>
-        </RepeatButton>
-        <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
-        <Track x:Name="PART_Track"
-                Grid.Column="1"
-                Height="2"
-                IsDirectionReversed="False"
-                IsEnabled="{TemplateBinding IsMouseOver}"
-                VerticalAlignment="Center">
-            <Track.DecreaseRepeatButton>
-                <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageLeftCommand}" />
-            </Track.DecreaseRepeatButton>
-            <Track.IncreaseRepeatButton>
-                <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageRightCommand}" />
-            </Track.IncreaseRepeatButton>
-            <Track.Thumb>
-                <Thumb />
-            </Track.Thumb>
-        </Track>
-        <RepeatButton x:Name="LineRightButton" 
-                      Grid.Column="2"
-                      Width="8"
-                      Style="{StaticResource ScrollBarLineButton}"
-                      Command="ScrollBar.LineRightCommand"
-                      VerticalAlignment="Center"
-                      Visibility="Collapsed" />
-      </Grid>
-      <ControlTemplate.Triggers>
-        <Trigger Property="IsMouseOver" Value="True">
-            <Setter TargetName="PART_Track" Property="Height" Value="6" />
-            <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
-            <Setter TargetName="LineLeftButton" Property="Visibility" Value="Visible" />
-            <Setter TargetName="LineRightButton" Property="Visibility" Value="Visible" />
-        </Trigger>
-      </ControlTemplate.Triggers>
+        <Grid SnapsToDevicePixels="True">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition MaxWidth="12" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition MaxWidth="12" />
+            </Grid.ColumnDefinitions>
+            <Border x:Name="ScrollBarBackground"
+                    Grid.ColumnSpan="3"
+                    Background="{StaticResource ScrollBarBackgroundBrush}"
+                    Opacity="0.01"
+                    CornerRadius="6" />
+            <RepeatButton x:Name="LineLeftButton"
+                          Grid.Column="0"
+                          Width="8"
+                          Style="{StaticResource ScrollBarLineButton}"
+                          Command="ScrollBar.LineLeftCommand"
+                          VerticalAlignment="Center"
+                          Visibility="Collapsed">
+                <RepeatButton.RenderTransform>
+                    <RotateTransform CenterX="4" CenterY="4" Angle="180" />
+                </RepeatButton.RenderTransform>
+            </RepeatButton>
+            <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+            <Track x:Name="PART_Track"
+                   Grid.Column="1"
+                   Height="2"
+                   IsDirectionReversed="False"
+                   IsEnabled="{TemplateBinding IsMouseOver}"
+                   VerticalAlignment="Center">
+                <Track.DecreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageLeftCommand}" />
+                </Track.DecreaseRepeatButton>
+                <Track.IncreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageRightCommand}" />
+                </Track.IncreaseRepeatButton>
+                <Track.Thumb>
+                    <Thumb />
+                </Track.Thumb>
+            </Track>
+            <RepeatButton x:Name="LineRightButton" 
+                          Grid.Column="2"
+                          Width="8"
+                          Style="{StaticResource ScrollBarLineButton}"
+                          Command="ScrollBar.LineRightCommand"
+                          VerticalAlignment="Center"
+                          Visibility="Collapsed" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="PART_Track" Property="Height" Value="6" />
+                    <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
+                    <Setter TargetName="LineLeftButton" Property="Visibility" Value="Visible" />
+                    <Setter TargetName="LineRightButton" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <ControlTemplate x:Key="VerticalScrollBar" TargetType="{x:Type ScrollBar}">
-      <Grid SnapsToDevicePixels="True">
-        <Grid.RowDefinitions>
-          <RowDefinition MaxHeight="12" />
-          <RowDefinition Height="*" />
-          <RowDefinition MaxHeight="12" />
-        </Grid.RowDefinitions>
-        <Border x:Name="ScrollBarBackground" 
-                Grid.RowSpan="3" 
-                Background="{StaticResource ScrollBarBackgroundBrush}" 
-                Opacity="0.01" 
-                CornerRadius="6" />
-        <RepeatButton x:Name="LineUpButton"
-                      Grid.Row="0"
-                      Height="8"
-                      Style="{StaticResource ScrollBarLineButton}"
-                      Command="ScrollBar.LineUpCommand"
-                      HorizontalAlignment="Center"
-                      Visibility="Collapsed">
-          <RepeatButton.RenderTransform>
-            <RotateTransform CenterX="4" CenterY="4" Angle="270" />
-          </RepeatButton.RenderTransform>
-        </RepeatButton>
-        <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
-        <Track x:Name="PART_Track"
-                Grid.Row="1"
-                Width="2"
-                IsDirectionReversed="True"
-                IsEnabled="{TemplateBinding IsMouseOver}"
-                HorizontalAlignment="Center">
-          <Track.DecreaseRepeatButton>
-            <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageUpCommand}" />
-          </Track.DecreaseRepeatButton>
-          <Track.IncreaseRepeatButton>
-            <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageDownCommand}" />
-          </Track.IncreaseRepeatButton>
-          <Track.Thumb>
-            <Thumb />
-          </Track.Thumb>
-        </Track>
-        <RepeatButton x:Name="LineDownButton"
-                      Grid.Row="2"
-                      Height="8"
-                      Style="{StaticResource ScrollBarLineButton}"
-                      Command="ScrollBar.LineDownCommand"
-                      HorizontalAlignment="Center"
-                      Visibility="Collapsed">
-          <RepeatButton.RenderTransform>
-            <RotateTransform CenterX="4" CenterY="4" Angle="90" />
-          </RepeatButton.RenderTransform>
-        </RepeatButton>
-      </Grid>
-      <ControlTemplate.Triggers>
-          <Trigger Property="IsMouseOver" Value="True">
-              <Setter TargetName="PART_Track" Property="Width" Value="6" />
-              <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
-              <Setter TargetName="LineUpButton" Property="Visibility" Value="Visible" />
-              <Setter TargetName="LineDownButton" Property="Visibility" Value="Visible" />
-          </Trigger>
-      </ControlTemplate.Triggers>
+        <Grid SnapsToDevicePixels="True">
+            <Grid.RowDefinitions>
+                <RowDefinition MaxHeight="12" />
+                <RowDefinition Height="*" />
+                <RowDefinition MaxHeight="12" />
+            </Grid.RowDefinitions>
+            <Border x:Name="ScrollBarBackground"
+                    Grid.RowSpan="3"
+                    Background="{StaticResource ScrollBarBackgroundBrush}"
+                    Opacity="0.01"
+                    CornerRadius="6" />
+            <RepeatButton x:Name="LineUpButton"
+                          Grid.Row="0"
+                          Height="8"
+                          Style="{StaticResource ScrollBarLineButton}"
+                          Command="ScrollBar.LineUpCommand"
+                          HorizontalAlignment="Center"
+                          Visibility="Collapsed">
+                <RepeatButton.RenderTransform>
+                    <RotateTransform CenterX="4" CenterY="4" Angle="270" />
+                </RepeatButton.RenderTransform>
+            </RepeatButton>
+            <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+            <Track x:Name="PART_Track"
+                   Grid.Row="1"
+                   Width="2"
+                   IsDirectionReversed="True"
+                   IsEnabled="{TemplateBinding IsMouseOver}"
+                   HorizontalAlignment="Center">
+                <Track.DecreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageUpCommand}" />
+                </Track.DecreaseRepeatButton>
+                <Track.IncreaseRepeatButton>
+                    <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageDownCommand}" />
+                </Track.IncreaseRepeatButton>
+                <Track.Thumb>
+                    <Thumb />
+                </Track.Thumb>
+            </Track>
+            <RepeatButton x:Name="LineDownButton"
+                          Grid.Row="2"
+                          Height="8"
+                          Style="{StaticResource ScrollBarLineButton}"
+                          Command="ScrollBar.LineDownCommand"
+                          HorizontalAlignment="Center"
+                          Visibility="Collapsed">
+                <RepeatButton.RenderTransform>
+                    <RotateTransform CenterX="4" CenterY="4" Angle="90" />
+                </RepeatButton.RenderTransform>
+            </RepeatButton>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="PART_Track" Property="Width" Value="6" />
+                <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
+                <Setter TargetName="LineUpButton" Property="Visibility" Value="Visible" />
+                <Setter TargetName="LineDownButton" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <Style TargetType="{x:Type ScrollBar}">
@@ -203,42 +202,42 @@
     <!-- By default, the ScrollViewer has a white square in the corner when both ScrollBars are visible.
          We don't want that corner square so we override the default style. -->
     <Style TargetType="{x:Type ScrollViewer}">
-      <Setter Property="OverridesDefaultStyle" Value="True"/>
-      <Setter Property="Template">
-        <Setter.Value>
-          <ControlTemplate TargetType="{x:Type ScrollViewer}">
-            <Grid>
-              <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-              </Grid.ColumnDefinitions>
-              <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-              </Grid.RowDefinitions>
-              
-              <ScrollContentPresenter Grid.Column="0" Grid.Row="0" />
-              
-              <ScrollBar x:Name="PART_VerticalScrollBar"
-                         Grid.Column="1"
-                         Grid.Row="0"
-                         Orientation="Vertical"
-                         Value="{TemplateBinding VerticalOffset}"
-                         Maximum="{TemplateBinding ScrollableHeight}"
-                         ViewportSize="{TemplateBinding ViewportHeight}"
-                         Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"/>
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                            
+                        <ScrollContentPresenter Grid.Column="0" Grid.Row="0" />
+                            
+                        <ScrollBar x:Name="PART_VerticalScrollBar"
+                                   Grid.Column="1"
+                                   Grid.Row="0"
+                                   Orientation="Vertical"
+                                   Value="{TemplateBinding VerticalOffset}"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"/>
 
-              <ScrollBar x:Name="PART_HorizontalScrollBar"
-                         Grid.Column="0"
-                         Grid.Row="1"
-                         Orientation="Horizontal"
-                         Value="{TemplateBinding HorizontalOffset}"
-                         Maximum="{TemplateBinding ScrollableWidth}"
-                         ViewportSize="{TemplateBinding ViewportWidth}"
-                         Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"/>
-            </Grid>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+                        <ScrollBar x:Name="PART_HorizontalScrollBar"
+                                   Grid.Column="0"
+                                   Grid.Row="1"
+                                   Orientation="Horizontal"
+                                   Value="{TemplateBinding HorizontalOffset}"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/Outlines.App/Resources/ScrollBarResources.xaml
+++ b/Outlines.App/Resources/ScrollBarResources.xaml
@@ -86,7 +86,7 @@
             <RotateTransform CenterX="4" CenterY="4" Angle="180" />
           </RepeatButton.RenderTransform>
         </RepeatButton>
-        <!-- The track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+        <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
         <Track x:Name="PART_Track"
                 Grid.Column="1"
                 Height="2"
@@ -144,7 +144,7 @@
             <RotateTransform CenterX="4" CenterY="4" Angle="270" />
           </RepeatButton.RenderTransform>
         </RepeatButton>
-        <!-- The track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+        <!-- The Track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
         <Track x:Name="PART_Track"
                 Grid.Row="1"
                 Width="2"
@@ -198,5 +198,47 @@
                 <Setter Property="Template" Value="{StaticResource VerticalScrollBar}" />
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+    <!-- By default, the ScrollViewer has a white square in the corner when both ScrollBars are visible.
+         We don't want that corner square so we override the default style. -->
+    <Style TargetType="{x:Type ScrollViewer}">
+      <Setter Property="OverridesDefaultStyle" Value="True"/>
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="{x:Type ScrollViewer}">
+            <Grid>
+              <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+              </Grid.ColumnDefinitions>
+              <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+              </Grid.RowDefinitions>
+              
+              <ScrollContentPresenter Grid.Column="0" Grid.Row="0" />
+              
+              <ScrollBar x:Name="PART_VerticalScrollBar"
+                         Grid.Column="1"
+                         Grid.Row="0"
+                         Orientation="Vertical"
+                         Value="{TemplateBinding VerticalOffset}"
+                         Maximum="{TemplateBinding ScrollableHeight}"
+                         ViewportSize="{TemplateBinding ViewportHeight}"
+                         Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"/>
+
+              <ScrollBar x:Name="PART_HorizontalScrollBar"
+                         Grid.Column="0"
+                         Grid.Row="1"
+                         Orientation="Horizontal"
+                         Value="{TemplateBinding HorizontalOffset}"
+                         Maximum="{TemplateBinding ScrollableWidth}"
+                         ViewportSize="{TemplateBinding ViewportWidth}"
+                         Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"/>
+            </Grid>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
     </Style>
 </ResourceDictionary>

--- a/Outlines.App/Resources/ScrollBarResources.xaml
+++ b/Outlines.App/Resources/ScrollBarResources.xaml
@@ -1,0 +1,202 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <SolidColorBrush x:Key="ThumbBackgroundBrush" Color="#9F9F9F" />
+    <SolidColorBrush x:Key="LineButtonRestBrush" Color="#9F9F9F" />
+    <SolidColorBrush x:Key="LineButtonHoveredBrush" Color="#CFCFCF" />
+    <SolidColorBrush x:Key="ScrollBarBackgroundBrush" Color="#5F5F5F" />
+  
+    <!-- Based on https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+    
+      <Style TargetType="{x:Type Thumb}">
+      <Setter Property="SnapsToDevicePixels" Value="True" />
+      <Setter Property="OverridesDefaultStyle" Value="True"/>
+      <Setter Property="IsTabStop" Value="False"/>
+      <Setter Property="Focusable" Value="False" />
+      <Setter Property="Background" Value="{StaticResource ThumbBackgroundBrush}" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="{x:Type Thumb}">
+            <Border x:Name="ThumbBackgroundBorder"
+                    Background="{TemplateBinding Background}"
+                    Height="{TemplateBinding Height}"
+                    Width="{TemplateBinding Width}" 
+                    SnapsToDevicePixels="True"
+                    CornerRadius="3" />
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+  
+    <Style x:Key="ScrollBarLineButton" TargetType="{x:Type RepeatButton}">
+      <Setter Property="SnapsToDevicePixels" Value="True" />
+      <Setter Property="OverridesDefaultStyle" Value="True" />
+      <Setter Property="Focusable" Value="False" />
+      <Setter Property="FontSize" Value="8" />
+      <Setter Property="FontFamily" Value="Segoe Fluent Icons" />
+      <Setter Property="Foreground" Value="{StaticResource LineButtonRestBrush}" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="{x:Type RepeatButton}">
+            <ContentPresenter Content="&#xF5B0;" />
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                  <Setter Property="Foreground" Value="{StaticResource LineButtonHoveredBrush}" />
+              </Trigger>
+          </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+  
+    <Style x:Key="ScrollBarPageButton" TargetType="{x:Type RepeatButton}">
+      <Setter Property="SnapsToDevicePixels" Value="True" />
+      <Setter Property="OverridesDefaultStyle" Value="True" />
+      <Setter Property="IsTabStop" Value="False" />
+      <Setter Property="Focusable" Value="False" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="{x:Type RepeatButton}">
+            <Border Background="Transparent" />
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <ControlTemplate x:Key="HorizontalScrollBar" TargetType="{x:Type ScrollBar}">
+      <Grid SnapsToDevicePixels="True">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition MaxWidth="12" />
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition MaxWidth="12" />
+        </Grid.ColumnDefinitions>
+        <Border x:Name="ScrollBarBackground" 
+                Grid.ColumnSpan="3" 
+                Background="{StaticResource ScrollBarBackgroundBrush}" 
+                Opacity="0.01" 
+                CornerRadius="6" />
+        <RepeatButton x:Name="LineLeftButton"
+                      Grid.Column="0"
+                      Width="8"
+                      Style="{StaticResource ScrollBarLineButton}"
+                      Command="ScrollBar.LineLeftCommand"
+                      VerticalAlignment="Center"
+                      Visibility="Collapsed">
+          <RepeatButton.RenderTransform>
+            <RotateTransform CenterX="4" CenterY="4" Angle="180" />
+          </RepeatButton.RenderTransform>
+        </RepeatButton>
+        <!-- The track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+        <Track x:Name="PART_Track"
+                Grid.Column="1"
+                Height="2"
+                IsDirectionReversed="False"
+                IsEnabled="{TemplateBinding IsMouseOver}"
+                VerticalAlignment="Center">
+            <Track.DecreaseRepeatButton>
+                <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageLeftCommand}" />
+            </Track.DecreaseRepeatButton>
+            <Track.IncreaseRepeatButton>
+                <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageRightCommand}" />
+            </Track.IncreaseRepeatButton>
+            <Track.Thumb>
+                <Thumb />
+            </Track.Thumb>
+        </Track>
+        <RepeatButton x:Name="LineRightButton" 
+                      Grid.Column="2"
+                      Width="8"
+                      Style="{StaticResource ScrollBarLineButton}"
+                      Command="ScrollBar.LineRightCommand"
+                      VerticalAlignment="Center"
+                      Visibility="Collapsed" />
+      </Grid>
+      <ControlTemplate.Triggers>
+        <Trigger Property="IsMouseOver" Value="True">
+            <Setter TargetName="PART_Track" Property="Height" Value="6" />
+            <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
+            <Setter TargetName="LineLeftButton" Property="Visibility" Value="Visible" />
+            <Setter TargetName="LineRightButton" Property="Visibility" Value="Visible" />
+        </Trigger>
+      </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="VerticalScrollBar" TargetType="{x:Type ScrollBar}">
+      <Grid SnapsToDevicePixels="True">
+        <Grid.RowDefinitions>
+          <RowDefinition MaxHeight="12" />
+          <RowDefinition Height="*" />
+          <RowDefinition MaxHeight="12" />
+        </Grid.RowDefinitions>
+        <Border x:Name="ScrollBarBackground" 
+                Grid.RowSpan="3" 
+                Background="{StaticResource ScrollBarBackgroundBrush}" 
+                Opacity="0.01" 
+                CornerRadius="6" />
+        <RepeatButton x:Name="LineUpButton"
+                      Grid.Row="0"
+                      Height="8"
+                      Style="{StaticResource ScrollBarLineButton}"
+                      Command="ScrollBar.LineUpCommand"
+                      HorizontalAlignment="Center"
+                      Visibility="Collapsed">
+          <RepeatButton.RenderTransform>
+            <RotateTransform CenterX="4" CenterY="4" Angle="270" />
+          </RepeatButton.RenderTransform>
+        </RepeatButton>
+        <!-- The track's name must be PART_Track, see doc: https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/scrollbar-styles-and-templates?view=netframeworkdesktop-4.8 -->
+        <Track x:Name="PART_Track"
+                Grid.Row="1"
+                Width="2"
+                IsDirectionReversed="True"
+                IsEnabled="{TemplateBinding IsMouseOver}"
+                HorizontalAlignment="Center">
+          <Track.DecreaseRepeatButton>
+            <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageUpCommand}" />
+          </Track.DecreaseRepeatButton>
+          <Track.IncreaseRepeatButton>
+            <RepeatButton Style="{StaticResource ScrollBarPageButton}" Command="{x:Static ScrollBar.PageDownCommand}" />
+          </Track.IncreaseRepeatButton>
+          <Track.Thumb>
+            <Thumb />
+          </Track.Thumb>
+        </Track>
+        <RepeatButton x:Name="LineDownButton"
+                      Grid.Row="2"
+                      Height="8"
+                      Style="{StaticResource ScrollBarLineButton}"
+                      Command="ScrollBar.LineDownCommand"
+                      HorizontalAlignment="Center"
+                      Visibility="Collapsed">
+          <RepeatButton.RenderTransform>
+            <RotateTransform CenterX="4" CenterY="4" Angle="90" />
+          </RepeatButton.RenderTransform>
+        </RepeatButton>
+      </Grid>
+      <ControlTemplate.Triggers>
+          <Trigger Property="IsMouseOver" Value="True">
+              <Setter TargetName="PART_Track" Property="Width" Value="6" />
+              <Setter TargetName="ScrollBarBackground" Property="Opacity" Value="0.1" />
+              <Setter TargetName="LineUpButton" Property="Visibility" Value="Visible" />
+              <Setter TargetName="LineDownButton" Property="Visibility" Value="Visible" />
+          </Trigger>
+      </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style TargetType="{x:Type ScrollBar}">
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Width" Value="Auto" />
+                <Setter Property="Height" Value="12" />
+                <Setter Property="Template" Value="{StaticResource HorizontalScrollBar}" />
+            </Trigger>
+            <Trigger Property="Orientation" Value="Vertical">
+                <Setter Property="Width" Value="12" />
+                <Setter Property="Height" Value="Auto" />
+                <Setter Property="Template" Value="{StaticResource VerticalScrollBar}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/Outlines.App/Views/UITreeView.xaml
+++ b/Outlines.App/Views/UITreeView.xaml
@@ -33,7 +33,7 @@
     </UserControl.Resources>
 
     <Grid x:Name="Root">
-        <StackPanel Margin="16,16,12,12">
+        <StackPanel Margin="16,16,4,4">
             <TextBlock Text="Tree View" Style="{StaticResource HeaderStyle}" />
             <TreeView ItemsSource="{Binding Elements}" Style="{StaticResource TreeViewStyle}" ItemContainerStyle="{StaticResource TreeViewItemStyle}" SelectedItemChanged="OnSelectedItemChanged">
                 <TreeView.Resources>


### PR DESCRIPTION
As described in issue #71, the default ScrollBar style did not fit with the Windows 11 design language and the rest of the app, this change overrides the style throughout the app to have it better fit.

## Screenshots

Before:
![ScrollBar_Before](https://user-images.githubusercontent.com/12770956/195065545-593b10a2-73f0-43d1-bcbf-3253ea2fda3b.png)

After:
![ScrollBar_After_Rest](https://user-images.githubusercontent.com/12770956/195066021-18776039-cff7-4842-abb6-e966ae402776.png)
![ScrollBar_After_Hovered](https://user-images.githubusercontent.com/12770956/195066040-62406f19-77e3-42f4-ac1f-565b2f050550.png)

