### PR TITLE
Fix MaxLines property for all properties in PropertiesPanel

### DIFF
--- a/Outlines.App/Views/PropertiesPanel.xaml
+++ b/Outlines.App/Views/PropertiesPanel.xaml
@@ -28,6 +28,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundColorBrush}" />
                 <Setter Property="TextTrimming" Value="CharacterEllipsis" />
                 <Setter Property="TextWrapping" Value="NoWrap" />
+                <Setter Property="MaxLines" Value="1" />
             </Style>
         </ResourceDictionary>
     </UserControl.Resources>


### PR DESCRIPTION
Fixes #115

Add `MaxLines` property to `PropertyValueStyle` in `PropertiesPanel.xaml`.

* Set `MaxLines` property to 1 in `PropertyValueStyle` to limit lines to 1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Remi05/outlines/pull/116?shareId=aafa029e-7a5f-49d7-b22b-8ff58ba8c3ea).