### PR TITLE
Fix CI build by updating deprecated action

### DIFF
--- a/.github/workflows/dotnet-core-windows.yml
+++ b/.github/workflows/dotnet-core-windows.yml
@@ -37,7 +37,7 @@ jobs:
       run: msbuild $env:Solution_Name /p:Configuration=${{matrix.configuration}} /p:Platform=${{matrix.platform}} /p:BuildingInsideVisualStudio=true
     
     - name: 'Publish Outlines App'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:	
         name: 'Outlines App'	
         path: '.\Outlines.App\bin\${{matrix.configuration}}\net6.0-windows10.0.22000\'


### PR DESCRIPTION
Fixes #117

Update the CI build configuration to use a non-deprecated version of `actions/upload-artifact`.

* Update `.github/workflows/dotnet-core-windows.yml` to use `actions/upload-artifact@v3` instead of `actions/upload-artifact@v2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Remi05/outlines/pull/118?shareId=5e6944bd-6fca-40e2-a903-9196768e1862).